### PR TITLE
Fix StateUtils.checkEnoughEnergy and EnergyMap.provides methods for Blend/Unit/Rapid Strike Energies

### DIFF
--- a/ptcg-server/.gitignore
+++ b/ptcg-server/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+output

--- a/ptcg-server/src/game/store/card/card-types.ts
+++ b/ptcg-server/src/game/store/card/card-types.ts
@@ -1,4 +1,3 @@
-
 export enum CardTag {
   POKEMON_SP = 'SP',
   POKEMON_EX = 'EX',
@@ -152,7 +151,8 @@ export enum CardType {
   GRW,
   LPM,
   FDY,
-  GRPD
+  GRPD,
+  RAPID_STRIKE
 }
 
 export enum SpecialCondition {

--- a/ptcg-server/src/game/store/card/card-utils.ts
+++ b/ptcg-server/src/game/store/card/card-utils.ts
@@ -1,0 +1,49 @@
+import { CardType } from './card-types';
+
+export class CardUtils {
+  public static readonly SPECIAL_ENERGY_TYPES: Partial<Record<CardType, CardType[]>> = {
+    [CardType.WLFM]: [W, L, F, M],
+    [CardType.GRPD]: [G, R, P, D],
+    [CardType.LPM]: [L, P, M],
+    [CardType.GRW]: [G, R, W],
+    [CardType.FDY]: [F, D, Y],
+    [CardType.RAPID_STRIKE]: [W, F]
+  };
+
+  public static createSpecialEnergyArray(specialType: CardType): CardType[] {
+    const providedTypes = this.SPECIAL_ENERGY_TYPES[specialType];
+    if (!providedTypes) {
+      return [specialType]; // Return original type if not special
+    }
+
+    const array = [specialType];
+    
+    // Override filter method
+    Object.defineProperty(array, 'filter', {
+      value: function(predicate: (type: CardType) => boolean) {
+        // Check if predicate matches any of our provided types
+        for (const type of providedTypes) {
+          if (predicate(type)) {
+            return [type];
+          }
+        }
+        // Otherwise use normal filter
+        return Array.prototype.filter.call(this, predicate);
+      }
+    });
+
+    // Override includes method
+    Object.defineProperty(array, 'includes', {
+      value: function(searchElement: CardType): boolean {
+        // Check if the type we're searching for is one of our provided types
+        if (providedTypes.includes(searchElement)) {
+          return true;
+        }
+        // Otherwise use normal includes
+        return Array.prototype.includes.call(this, searchElement);
+      }
+    });
+
+    return array;
+  }
+}

--- a/ptcg-server/src/game/store/state-utils.spec.ts
+++ b/ptcg-server/src/game/store/state-utils.spec.ts
@@ -1,18 +1,29 @@
 import { CardType, SuperType } from './card/card-types';
 import { EnergyMap } from './prompts/choose-energy-prompt';
 import { StateUtils } from './state-utils';
+import { BlendEnergyWLFM } from '../../sets/set-dragons-exalted/blend-energy-wlfm';
+import { Effect } from './effects/effect';
+import { CheckProvidedEnergyEffect, CheckRetreatCostEffect } from './effects/check-effects';
+import { StoreLike } from './store-like';
+import { State } from './state/state';
+import { ZeraoraGX } from '../../sets/set-lost-thunder/zeraora-gx';
+import { UnitEnergyLPM } from '../../sets/set-ultra-prism/unit-energy-lpm';
 
 describe('StateUtils', () => {
 
   // let playerId: number;
   let fire: CardType[];
   let fighting: CardType[];
+  let lightning: CardType[];
+  let water: CardType[];
   let unitFdy: CardType[];
   let blendWLFM: CardType[];
   let unitLPM: CardType[];
+  let unitGRW: CardType[];
+  let rainbow: CardType[];
+  let blendGRPD: CardType[];
   // let dark: CardType[];
   // let colorless: CardType[];
-  let rainbow: CardType[];
   // let dce: CardType[];
 
   function createEnergy(name: string, provides: CardType[]): EnergyMap {
@@ -22,20 +33,22 @@ describe('StateUtils', () => {
 
   beforeEach(() => {
     // playerId = 1;
-    fire = [ CardType.FIRE ];
-    fighting = [ CardType.FIGHTING ];
-    // dark = [ CardType.DARK ];
+    fire = [ R ];
+    fighting = [ F ];
+    lightning = [ L ];
+    water = [ W ];
     unitFdy = [ CardType.FDY ];
     blendWLFM = [ CardType.WLFM ];
     unitLPM = [ CardType.LPM ];
-    // colorless = [ CardType.COLORLESS ];
+    unitGRW = [ CardType.GRW ];
     rainbow = [ CardType.ANY ];
-    // dce = [ CardType.COLORLESS, CardType.COLORLESS ];
+    blendGRPD = [ CardType.GRPD ];
+    // dce = [ C, C ];
   });
 
   it('Should return true, when provided the correct energy', () => {
     // given
-    const cost: CardType[] = [ CardType.FIRE ];
+    const cost: CardType[] = [ R ];
     const energy: EnergyMap[] = [
       createEnergy('fire', fire)
     ];
@@ -46,7 +59,7 @@ describe('StateUtils', () => {
   
   it('Should return false when provided too few energy', () => {
     // given
-    const cost: CardType[] = [ CardType.FIRE, CardType.FIRE ];
+    const cost: CardType[] = [ R, R ];
     const energy: EnergyMap[] = [
       createEnergy('fire', fire)
     ];
@@ -57,7 +70,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided rainbow energy', () => {
     // given
-    const cost: CardType[] = [ CardType.FIRE, CardType.FIRE ];
+    const cost: CardType[] = [ R, R ];
     const energy: EnergyMap[] = [
       createEnergy('fire', fire),
       createEnergy('rainbow', rainbow)
@@ -69,7 +82,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided fdy', () => {
     // given
-    const cost: CardType[] = [ CardType.FIGHTING, CardType.FAIRY ];
+    const cost: CardType[] = [ F, Y ];
     const energy: EnergyMap[] = [
       createEnergy('fighting', fighting),
       createEnergy('unitFdy', unitFdy)
@@ -81,7 +94,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided with multiple blends that match out of order energy cost', () => {
     // given
-    const cost: CardType[] = [ CardType.WATER, CardType.LIGHTNING ];
+    const cost: CardType[] = [ W, L ];
     const energy: EnergyMap[] = [
       createEnergy('unitLPM', unitLPM),
       createEnergy('blendWLFM', blendWLFM),
@@ -93,7 +106,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided with multiple blends and a rainbow that match out of order energy cost', () => {
     // given
-    const cost: CardType[] = [ CardType.WATER, CardType.LIGHTNING, CardType.GRASS ];
+    const cost: CardType[] = [ W, L, G ];
     const energy: EnergyMap[] = [
       createEnergy('unitLPM', unitLPM),
       createEnergy('rainbow', rainbow),
@@ -106,7 +119,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided with too much energy', () => {
     // given
-    const cost: CardType[] = [ CardType.FIGHTING, CardType.FIGHTING ];
+    const cost: CardType[] = [ F, F ];
     const energy: EnergyMap[] = [
       createEnergy('fighting', fighting),
       createEnergy('fighting', fighting),
@@ -119,7 +132,7 @@ describe('StateUtils', () => {
   
   it('Should return true when provided with all rainbows', () => {
     // given
-    const cost: CardType[] = [ CardType.FIGHTING, CardType.FIGHTING ];
+    const cost: CardType[] = [ F, F ];
     const energy: EnergyMap[] = [
       createEnergy('rainbow', rainbow),
       createEnergy('rainbow', rainbow),
@@ -127,5 +140,268 @@ describe('StateUtils', () => {
 
     // then
     expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle two Unit LPM for {L}{L} cost', () => {
+    // given
+    const cost: CardType[] = [ L, L ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitLPM1', unitLPM),
+      createEnergy('unitLPM2', unitLPM)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle two Unit GRW for {R}{R} cost', () => {
+    // given
+    const cost: CardType[] = [ R, R ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitGRW1', unitGRW),
+      createEnergy('unitGRW2', unitGRW)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle different multi-energies for same type cost', () => {
+    // given
+    const cost: CardType[] = [ R, R ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitGRW', unitGRW),
+      createEnergy('blendGRPD', blendGRPD)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle Unit LPM + Blend WLFM for {L}{M} cost', () => {
+    // given
+    const cost: CardType[] = [ L, M ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitLPM', unitLPM),
+      createEnergy('blendWLFM', blendWLFM)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle Unit GRW + Blend GRPD for {R}{W} cost', () => {
+    // given
+    const cost: CardType[] = [ R, W ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitGRW', unitGRW),
+      createEnergy('blendGRPD', blendGRPD)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+  
+  it('Should handle two different Blend energies for {L}{P} cost', () => {
+    // given
+    const cost: CardType[] = [ L, P ];
+    const energy: EnergyMap[] = [
+      createEnergy('blendWLFM', blendWLFM),
+      createEnergy('blendGRPD', blendGRPD)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle same Blend energy twice for {W}{F} cost', () => {
+    // given
+    const cost: CardType[] = [ W, F ];
+    const energy: EnergyMap[] = [
+      createEnergy('blendWLFM1', blendWLFM),
+      createEnergy('blendWLFM2', blendWLFM)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should fail when one multi-energy provides a cost but not the other', () => {
+    // given
+    const cost: CardType[] = [ P, P ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitLPM', unitLPM),
+      createEnergy('blendWLFM', blendWLFM)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeFalsy();
+  });
+
+  it('Should handle complex mix of basic and multi-energies', () => {
+    // given
+    const cost: CardType[] = [ 
+      L, 
+      P, 
+      W,
+      C 
+    ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitLPM', unitLPM),
+      createEnergy('blendWLFM', blendWLFM),
+      createEnergy('lightning', lightning),
+      createEnergy('water', water)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle ANY type from rainbow with multi-energies', () => {
+    const cost: CardType[] = [ 
+      L, 
+      P, 
+      W 
+    ];
+    const energy: EnergyMap[] = [
+      createEnergy('unitLPM', unitLPM),
+      createEnergy('rainbow', rainbow),
+      createEnergy('blendWLFM', blendWLFM)
+    ];
+
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle energy assignment regardless of energy card order', () => {
+    // given
+    const cost: CardType[] = [ R, P ];
+    
+    const energy1: EnergyMap[] = [
+      createEnergy('blendGRPD', blendGRPD),
+      createEnergy('unitLPM', unitLPM)
+    ];
+    
+    const energy2: EnergyMap[] = [
+      createEnergy('unitLPM', unitLPM),
+      createEnergy('blendGRPD', blendGRPD)
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy1, cost)).toBeTruthy();
+    expect(StateUtils.checkEnoughEnergy(energy2, cost)).toBeTruthy();
+  });
+
+  it('Should handle Double Turbo Energy for {C}{C} cost', () => {
+    // given
+    const cost: CardType[] = [ C, C ];
+    const energy: EnergyMap[] = [
+      createEnergy('doubleTurbo', [ C, C ])
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle Double Dragon Energy for {R}{L} cost', () => {
+    // given
+    const cost: CardType[] = [ R, L ];
+    const energy: EnergyMap[] = [
+      createEnergy('doubleDragon', [ CardType.ANY, CardType.ANY ])
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should handle Rapid Strike Energy for {W}{F} cost', () => {
+    // given
+    const cost: CardType[] = [ W, F ];
+    const energy: EnergyMap[] = [
+      createEnergy('rapidStrike', [ CardType.RAPID_STRIKE, CardType.RAPID_STRIKE ])
+    ];
+
+    // then
+    expect(StateUtils.checkEnoughEnergy(energy, cost)).toBeTruthy();
+  });
+
+  it('Should count Blend WLFM as [W] for attack damage calculation', () => {
+    // given
+    const blendEnergy = new BlendEnergyWLFM();
+    const checkEffect = new CheckProvidedEnergyEffect({
+      id: 1,
+      active: {
+        cards: [blendEnergy]  // Need to include the energy card in the source
+      }
+    } as any);
+
+    // Mock store to prevent EnergyEffect errors
+    const mockStore = {
+      reduceEffect: () => ({} as any)
+    } as unknown as StoreLike;
+
+    blendEnergy.reduceEffect(mockStore, {} as State, checkEffect);
+
+    const energy: EnergyMap[] = [
+      createEnergy('water', water),
+      checkEffect.energyMap[0] // Use the actual energy map from BlendEnergyWLFM
+    ];
+
+    // Create a custom filter predicate like the one in Horsea's attack
+    const waterFilter = (cardType: CardType) => 
+      cardType === W || cardType === CardType.ANY;
+
+    // Count total Water energies
+    let waterCount = 0;
+    energy.forEach(em => {
+      waterCount += em.provides.filter(waterFilter).length;
+    });
+
+    // then
+    expect(waterCount).toBe(2); // Should count both basic Water and Blend WLFM
+  });
+
+  it('Should count Unit Energy LPM as [L] for retreat cost abilities', () => {
+    // given
+    const zeraora = new ZeraoraGX();
+    const unitEnergyLPM = new UnitEnergyLPM();
+    
+    // First check the provided energy
+    const checkProvidedEnergy = new CheckProvidedEnergyEffect({
+      id: 1,
+      active: {
+        cards: [zeraora, unitEnergyLPM],
+        getPokemonCard: () => zeraora
+      }
+    } as any);
+
+    // Then check retreat cost
+    const checkRetreatCost = new CheckRetreatCostEffect({
+      id: 1,
+      active: {
+        cards: [zeraora, unitEnergyLPM],
+        getPokemonCard: () => zeraora
+      }
+    } as any);
+
+    // Mock store to handle both effects
+    const mockStore = {
+      reduceEffect: (state: State, effect: Effect) => {
+        if (effect instanceof CheckProvidedEnergyEffect) {
+          effect.energyMap.push({
+            card: unitEnergyLPM,
+            provides: [L, P, M]
+          });
+        }
+        return state;
+      }
+    } as unknown as StoreLike;
+
+    // when - first get the energy provided
+    unitEnergyLPM.reduceEffect(mockStore, {} as State, checkProvidedEnergy);
+    // then check if it affects retreat cost
+    zeraora.reduceEffect(mockStore, {} as State, checkRetreatCost);
+
+    // then
+    expect(checkRetreatCost.cost).toEqual([]);
   });
 });

--- a/ptcg-server/src/game/store/state-utils.ts
+++ b/ptcg-server/src/game/store/state-utils.ts
@@ -8,171 +8,95 @@ import { CardList } from './state/card-list';
 import { Player } from './state/player';
 import { PokemonCardList } from './state/pokemon-card-list';
 import { State } from './state/state';
+import { CardUtils } from './card/card-utils';
 
 export class StateUtils {
   static getStadium(state: State) {
     throw new Error('Method not implemented.');
   }
-  public static checkEnoughEnergy(energy: EnergyMap[], cost: CardType[]): boolean {
-    if (cost.length === 0) {
+  public static checkEnoughEnergy(energyMap: EnergyMap[], cost: CardType[]): boolean {
+    // Step 1: Split the attack cost into hued energies (like Fire, Water) and colorless count
+    // For example: cost of [F,W,C,C] becomes huesNeeded=[F,W] and colorlessNeeded=2
+    const huesNeeded: CardType[] = [];
+    let colorlessNeeded = 0;
+    for (const c of cost) {
+      if (c === CardType.COLORLESS) {
+        colorlessNeeded++;
+      } else if (c !== CardType.NONE && c !== CardType.ANY) {
+        huesNeeded.push(c);
+      }
+    }
+
+    // Step 2: Convert each Energy card's "provides" into its full set of possible types
+    // For example: 
+    // - A Basic Fire Energy's [F] stays as [F]
+    // - Unit Energy LPM's [LPM] explodes to [L,P,M]
+    // - Blend Energy WLFM's [WLFM] explodes to [W,L,F,M]
+    const providedEnergyUnits: CardType[] = energyMap.flatMap(e => e.provides); // Flatten multiple provides
+    const providedEnergySets: CardType[][] = [];
+    
+    providedEnergyUnits.forEach(type => {
+      if (type === CardType.ANY) {
+        providedEnergySets.push([CardType.ANY]);
+      } else if (CardUtils.SPECIAL_ENERGY_TYPES[type]) {
+        providedEnergySets.push(CardUtils.SPECIAL_ENERGY_TYPES[type]!);
+      } else {
+        providedEnergySets.push([type]);
+      }
+    });
+
+    // Step 3: Use backtracking to find a valid assignment of Energy cards to hued costs
+    // For example: If we need [L,P] and have Unit LPM + Blend WLFM:
+    // - Try assigning Unit LPM to L, then see if Blend WLFM can provide P
+    // - If that fails, try Unit LPM for P and Blend WLFM for L
+    // - If any combination works, return true
+    if (!StateUtils.canFulfillCosts(providedEnergySets, huesNeeded)) {
+      return false;
+    }
+
+    // Step 4: If we found a valid way to cover all hued costs,
+    // ensure we have enough total Energy cards left to cover colorless
+    // Simple check: Do we have at least (hued costs + colorless costs) total Energy cards?
+    if (providedEnergyUnits.length < (huesNeeded.length + colorlessNeeded)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Uses backtracking and recursion to find a valid assignment of Energy cards to hued costs
+   * @param provided Array of what each Energy card can provide (e.g. [[L,P,M], [W,L,F,M]])
+   * @param needed Array of required hued Energy (e.g. [L,P])
+   * @returns boolean indicating whether a valid assignment was found
+   */
+  private static canFulfillCosts(provided: CardType[][], needed: CardType[]): boolean {
+    // Base case: if no more hued needs, we've found a valid assignment
+    if (needed.length === 0) {
       return true;
     }
 
-    const provides: CardType[] = [];
-    energy.forEach(e => {
-      e.provides.forEach(cardType => provides.push(cardType));
-    });
+    const required = needed[0];  // Take the first needed type/hue
+    
+    // Try each available Energy card to fulfill this need
+    for (let i = 0; i < provided.length; i++) {
+      const set = provided[i];
+      // If this Energy can provide the needed type/hue
+      if (set.includes(required) || set.includes(CardType.ANY)) {
+        // Remove this Energy from available pool (since it can only be used once)
+        const newSets = provided.slice();
+        newSets.splice(i, 1);
 
-    let colorless = 0;
-    let rainbow = 0;
-
-    let needsProviding: CardType[] = [];
-
-    // First remove from array cards with specific energy types
-    cost.forEach(costType => {
-      switch (costType) {
-        case CardType.ANY:
-        case CardType.NONE:
-          break;
-        case CardType.COLORLESS:
-          colorless += 1;
-          break;
-        default: {
-          const index = provides.findIndex(energy => energy === costType);
-          if (index !== -1) {
-            provides.splice(index, 1);
-          } else {
-            needsProviding.push(costType);
-            rainbow += 1;
-          }
+        // Recursively try to fulfill the remaining needs with remaining energies
+        const newNeeded = needed.slice(1);
+        if (StateUtils.canFulfillCosts(newSets, newNeeded)) {
+          return true;  // Found a valid assignment!
         }
-      }
-    });
-
-    // BEGIN HANDLING BLEND ENERGIES
-    const blendProvides: CardType[][] = [];
-
-    // Check blend/unit energies
-    provides.forEach((cardType, index) => {
-      switch (cardType) {
-        case CardType.LPM:
-          blendProvides.push([CardType.LIGHTNING, CardType.PSYCHIC, CardType.METAL]);
-          break;
-        case CardType.GRW:
-          blendProvides.push([CardType.GRASS, CardType.FIRE, CardType.WATER]);
-          break;
-        case CardType.FDY:
-          blendProvides.push([CardType.FAIRY, CardType.DARK, CardType.FIGHTING]);
-          break;
-        case CardType.WLFM:
-          blendProvides.push([CardType.WATER, CardType.LIGHTNING, CardType.FIGHTING, CardType.METAL]);
-          break;
-        case CardType.GRPD:
-          blendProvides.push([CardType.GRASS, CardType.FIRE, CardType.PSYCHIC, CardType.DARK]);
-          break;
-        default:
-          return;
-      }
-    });
-
-    const possibleBlendPermutations = this.getCombinations(blendProvides, blendProvides.length);
-    let needsProvidingPermutations: CardType[][] = [];
-
-    if (needsProviding.length === 1) {
-      needsProvidingPermutations.push(needsProviding);
-    } else if (needsProviding.length > 1) {
-      permutations(needsProviding, needsProviding.length);
-    }
-
-    // check needs providing from blendProvides
-    // subtract 1 from rainbow when find is successful
-    let needsProvidingMatchIndex = 0;
-    let maxMatches = 0;
-
-    possibleBlendPermutations.forEach((energyTypes, index) => {
-      let matches = 0;
-      for (let i = 0; i < needsProvidingPermutations.length; i++) {
-        for (let j = 0; j < needsProvidingPermutations[i].length; j++) {
-          if (energyTypes[j] === needsProvidingPermutations[i][j]) {
-            matches++;
-          }
-        }
-
-        if (matches > maxMatches) {
-          maxMatches = matches;
-          needsProvidingMatchIndex = i;
-        }
-      }
-    });
-
-    // remove blend matches from rainbow requirement
-    rainbow -= maxMatches;
-
-    // remove matched energy from provides
-    for (let i = 0; i < maxMatches; i++) {
-      const index = provides.findIndex(energy => energy === needsProvidingPermutations[needsProvidingMatchIndex][i]);
-      provides.splice(index, 1);
-    }
-    // END HANDLING BLEND ENERGIES
-
-    // Check if we have enough rainbow energies
-    for (let i = 0; i < rainbow; i++) {
-      const index = provides.findIndex(energy => energy === CardType.ANY);
-      if (index !== -1) {
-        provides.splice(index, 1);
-      } else {
-        return false;
+        // If that didn't work, the loop continues to try the next Energy card
       }
     }
-
-    // Rest cards can be used to pay for colorless energies
-    return provides.length >= colorless;
-
-
-    // permutations calculation helper function
-    function permutations(array: CardType[], currentSize: number) {
-      if (currentSize == 1) { // recursion base-case (end)
-        needsProvidingPermutations.push(array.join("").split("").map(x => parseInt(x)));
-      }
-
-      for (let i = 0; i < currentSize; i++) {
-        permutations(array, currentSize - 1);
-        if (currentSize % 2 == 1) {
-          let temp = array[0];
-          array[0] = array[currentSize - 1];
-          array[currentSize - 1] = temp;
-        } else {
-          let temp = array[i];
-          array[i] = array[currentSize - 1];
-          array[currentSize - 1] = temp;
-        }
-      }
-    }
-  }
-
-  static getCombinations(arr: CardType[][], n: number): CardType[][] {
-    var i, j, k, l = arr.length, childperm, ret = [];
-    var elem: CardType[] = [];
-    if (n == 1) {
-      for (i = 0; i < arr.length; i++) {
-        for (j = 0; j < arr[i].length; j++) {
-          ret.push([arr[i][j]]);
-        }
-      }
-      return ret;
-    }
-    else {
-      for (i = 0; i < l; i++) {
-        elem = arr.shift()!;
-        for (j = 0; j < elem.length; j++) {
-          childperm = this.getCombinations(arr.slice(), n - 1);
-          for (k = 0; k < childperm.length; k++) {
-            ret.push([elem[j]].concat(childperm[k]));
-          }
-        }
-      }
-      return ret;
-    }
+    // If we tried all energies and found no valid assignment, return false
+    return false;
   }
 
   public static checkExactEnergy(energy: EnergyMap[], cost: CardType[]): boolean {
@@ -271,5 +195,4 @@ export class StateUtils {
     }
     return undefined;
   }
-
 }

--- a/ptcg-server/src/sets/set-battle-styles/rapid-strike-energy.ts
+++ b/ptcg-server/src/sets/set-battle-styles/rapid-strike-energy.ts
@@ -1,4 +1,4 @@
-import { CardTag, CardType, EnergyType, SuperType } from '../../game/store/card/card-types';
+import { CardTag, CardType, EnergyType } from '../../game/store/card/card-types';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { StoreLike } from '../../game/store/store-like';
 import { State } from '../../game/store/state/state';
@@ -6,6 +6,7 @@ import { Effect } from '../../game/store/effects/effect';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { PlayerType } from '../../game';
 import { AttachEnergyEffect, EnergyEffect } from '../../game/store/effects/play-card-effects';
+import { CardUtils } from '../../game/store/card/card-utils';
 
 export class RapidStrikeEnergy extends EnergyCard {
 
@@ -46,24 +47,15 @@ export class RapidStrikeEnergy extends EnergyCard {
       }
 
       const pokemonCard = pokemon.getPokemonCard();
+
       if (pokemonCard?.tags.includes(CardTag.RAPID_STRIKE)) {
-        const attackCosts = pokemonCard.attacks.map(attack => attack.cost);
-        const existingEnergy = pokemon.cards.filter(c => c.superType === SuperType.ENERGY);
-
-        const existingWater = existingEnergy.filter(c => 'provides' in c && (c as EnergyCard).provides.includes(CardType.WATER)).length;
-        const existingFighting = existingEnergy.filter(c => 'provides' in c && (c as EnergyCard).provides.includes(CardType.FIGHTING)).length;
-        const needsWater = attackCosts.some(cost => cost.filter(c => c === CardType.WATER).length > existingWater);
-        const needsFighting = attackCosts.some(cost => cost.filter(c => c === CardType.FIGHTING).length > existingFighting);
-
-        if (needsWater && needsFighting) {
-          effect.energyMap.push({ card: this, provides: [CardType.WATER, CardType.FIGHTING] });
-        } else if (needsWater) {
-          effect.energyMap.push({ card: this, provides: [CardType.WATER, CardType.WATER] });
-        } else if (needsFighting) {
-          effect.energyMap.push({ card: this, provides: [CardType.FIGHTING, CardType.FIGHTING] });
-        } else {
-          effect.energyMap.push({ card: this, provides: [CardType.COLORLESS] });
-        }
+        effect.energyMap.push({
+          card: this,
+          provides: [
+            ...CardUtils.createSpecialEnergyArray(CardType.RAPID_STRIKE),
+            ...CardUtils.createSpecialEnergyArray(CardType.RAPID_STRIKE)
+          ]
+        });
       }
       return state;
     }

--- a/ptcg-server/src/sets/set-dragons-exalted/blend-energy-grpd.ts
+++ b/ptcg-server/src/sets/set-dragons-exalted/blend-energy-grpd.ts
@@ -1,4 +1,5 @@
 import { CardType, EnergyType } from '../../game/store/card/card-types';
+import { CardUtils } from '../../game/store/card/card-utils';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
@@ -24,33 +25,18 @@ export class BlendEnergyGRPD extends EnergyCard {
 
   public text = 'This card provides [C] Energy. When this card is attached to a Pokémon, this card provides [G], [R], [P], or [D] Energy but provides only 1 Energy at a time.';
 
-  blendedEnergies = [CardType.GRASS, CardType.FIRE, CardType.PSYCHIC, CardType.DARK];
-
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
-      const player = effect.player;
-      const pokemon = effect.source;
-
       try {
-        const energyEffect = new EnergyEffect(player, this);
+        const energyEffect = new EnergyEffect(effect.player, this);
         store.reduceEffect(state, energyEffect);
       } catch {
         return state;
       }
 
-      const pokemonCard = pokemon.getPokemonCard();
-      const attackCosts = pokemonCard?.attacks.map(attack => attack.cost);
-
-      const costs = attackCosts?.flat().filter(t => t !== CardType.COLORLESS) || [];
-      const alreadyProvided = effect.energyMap.flatMap(e => e.provides);
-      const neededType = costs.find(cost =>
-        this.blendedEnergies.includes(cost) &&
-        !alreadyProvided.includes(cost)
-      );
-
       effect.energyMap.push({
         card: this,
-        provides: neededType ? [neededType] : [CardType.COLORLESS]
+        provides: CardUtils.createSpecialEnergyArray(CardType.GRPD)
       });
     }
     return state;

--- a/ptcg-server/src/sets/set-dragons-exalted/blend-energy-wlfm.ts
+++ b/ptcg-server/src/sets/set-dragons-exalted/blend-energy-wlfm.ts
@@ -1,6 +1,7 @@
 import { CardType, EnergyType } from '../../game/store/card/card-types';
+import { CardUtils } from '../../game/store/card/card-utils';
 import { EnergyCard } from '../../game/store/card/energy-card';
-import { CheckAttackCostEffect, CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
+import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
 import { EnergyEffect } from '../../game/store/effects/play-card-effects';
 import { State } from '../../game/store/state/state';
@@ -22,61 +23,22 @@ export class BlendEnergyWLFM extends EnergyCard {
 
   public fullName = 'Blend Energy WLFM DRX';
 
-  public text = 'This card provides C Energy. When this card is attached to a Pokémon, this card provides W, L, F, or M Energy but provides only 1 Energy at a time.';
-
-  blendedEnergies = [CardType.WATER, CardType.LIGHTNING, CardType.FIGHTING, CardType.METAL];
+  public text = 'This card provides [C] Energy. When attached to a Pokémon, this card provides [W], [L], [F], or [M] but only 1 Energy at a time.';
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
-    if (effect instanceof CheckAttackCostEffect && effect.player.active.cards.includes(this)) {
-      const player = effect.player;
-      const pokemon = effect.player.active;
-
+    if (effect instanceof CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
       try {
-        const energyEffect = new EnergyEffect(player, this);
+        const energyEffect = new EnergyEffect(effect.player, this);
         store.reduceEffect(state, energyEffect);
       } catch {
         return state;
       }
 
-      const attackCosts = effect instanceof CheckAttackCostEffect ? effect.attack.cost : [];
-      const initialCosts = [...attackCosts];
-      console.log(`[BlendEnergy] Initial attack costs: ${initialCosts.join(', ') || 'None'}`);
-
-      let checkEnergy: CheckProvidedEnergyEffect;
-      if (effect instanceof CheckProvidedEnergyEffect) {
-        checkEnergy = effect;
-      } else {
-        checkEnergy = new CheckProvidedEnergyEffect(player, pokemon);
-        store.reduceEffect(state, checkEnergy);
-      }
-
-      const alreadyProvided = checkEnergy.energyMap.flatMap(e => e.provides);
-      const blendProvided = checkEnergy.energyMap
-        .filter(e => e.card instanceof BlendEnergyWLFM)
-        .flatMap(e => e.provides);
-
-      let neededType: CardType | undefined;
-      for (const cost of initialCosts) {
-        if (this.blendedEnergies.includes(cost) && !alreadyProvided.includes(cost) && !blendProvided.includes(cost)) {
-          neededType = cost;
-          break;
-        }
-      }
-
-      if (neededType) {
-        checkEnergy.energyMap.push({
-          card: this,
-          provides: [neededType]
-        });
-        console.log(`[BlendEnergy] Provided energy type: ${neededType}`);
-      }
-
-      const finalEnergy = checkEnergy.energyMap.flatMap(e => e.provides);
-      console.log(`[BlendEnergy] Final energy provided: ${finalEnergy.join(', ') || 'None'}`);
-      console.log(`[BlendEnergy] Final attack cost check: ${effect.attack.cost.join(', ')}`);
+      effect.energyMap.push({
+        card: this,
+        provides: CardUtils.createSpecialEnergyArray(CardType.WLFM)
+      });
     }
     return state;
-
-
   }
 }

--- a/ptcg-server/src/sets/set-evolving-skies/regieleki.ts
+++ b/ptcg-server/src/sets/set-evolving-skies/regieleki.ts
@@ -79,7 +79,7 @@ export class Regieleki extends PokemonCard {
 
         const cards: Card[] = [];
         for (const energyMap of checkProvidedEnergy.energyMap) {
-          const energy = energyMap.provides.filter(t => t === CardType.LIGHTNING || t === CardType.ANY || t === CardType.WLFM || t === CardType.LPM);
+          const energy = energyMap.provides.filter(t => t === CardType.LIGHTNING || t === CardType.ANY);
           if (energy.length > 0) {
             cards.push(energyMap.card);
           }

--- a/ptcg-server/src/sets/set-forbidden-light/unit-energy-fdy.ts
+++ b/ptcg-server/src/sets/set-forbidden-light/unit-energy-fdy.ts
@@ -1,4 +1,5 @@
 import { CardType, EnergyType } from '../../game/store/card/card-types';
+import { CardUtils } from '../../game/store/card/card-utils';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
@@ -30,29 +31,16 @@ export class UnitEnergyFDY extends EnergyCard {
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
-      const player = effect.player;
-      const pokemon = effect.source;
-
       try {
-        const energyEffect = new EnergyEffect(player, this);
+        const energyEffect = new EnergyEffect(effect.player, this);
         store.reduceEffect(state, energyEffect);
       } catch {
         return state;
       }
 
-      const pokemonCard = pokemon.getPokemonCard();
-      const attackCosts = pokemonCard?.attacks.map(attack => attack.cost);
-
-      const costs = attackCosts?.flat().filter(t => t !== CardType.COLORLESS) || [];
-      const alreadyProvided = effect.energyMap.flatMap(e => e.provides);
-      const neededType = costs.find(cost =>
-        this.blendedEnergies.includes(cost) &&
-        !alreadyProvided.includes(cost)
-      );
-
       effect.energyMap.push({
         card: this,
-        provides: neededType ? [neededType] : [CardType.COLORLESS]
+        provides: CardUtils.createSpecialEnergyArray(CardType.FDY)
       });
     }
     return state;

--- a/ptcg-server/src/sets/set-lost-thunder/white-kyurem.ts
+++ b/ptcg-server/src/sets/set-lost-thunder/white-kyurem.ts
@@ -70,7 +70,7 @@ export class WhiteKyurem extends PokemonCard {
       const checkProvidedEnergy = new CheckProvidedEnergyEffect(player, player.active);
       store.reduceEffect(state, checkProvidedEnergy);
       
-      const hasFireEnergy = checkProvidedEnergy.energyMap.some(e => e.provides.includes(CardType.ANY) || e.provides.includes(CardType.FIRE) || e.provides.includes(CardType.GRW) || e.provides.includes(CardType.GRPD));
+      const hasFireEnergy = checkProvidedEnergy.energyMap.some(e => e.provides.includes(CardType.ANY) || e.provides.includes(CardType.FIRE));
       
       if (hasFireEnergy) {
         effect.damage += 80;

--- a/ptcg-server/src/sets/set-paldea-evolved/orthworm.ts
+++ b/ptcg-server/src/sets/set-paldea-evolved/orthworm.ts
@@ -87,7 +87,7 @@ export class Orthworm extends PokemonCard {
 
       let metalEnergy = 0;
       for (const energyMap of checkProvidedEnergy.energyMap) {
-        const energy = energyMap.provides.filter(t => t === CardType.METAL || t === CardType.ANY || CardType.LPM || CardType.WLFM);
+        const energy = energyMap.provides.filter(t => t === CardType.METAL || t === CardType.ANY);
         if (energy.length > 0) {
           metalEnergy += energy.length;
         }

--- a/ptcg-server/src/sets/set-paradox-rift/veluza.ts
+++ b/ptcg-server/src/sets/set-paradox-rift/veluza.ts
@@ -67,7 +67,7 @@ export class Veluza extends PokemonCard {
         PlayerType.BOTTOM_PLAYER,
         [SlotType.BENCH],
         { superType: SuperType.ENERGY },
-        { allowCancel: false, min: 0, max: 2, validCardTypes: [CardType.WATER, CardType.ANY, CardType.WLFM, CardType.GRW] }
+        { allowCancel: false, min: 0, max: 2, validCardTypes: [CardType.WATER, CardType.ANY] }
       ), transfers => {
         transfers = transfers || [];
         for (const transfer of transfers) {
@@ -86,7 +86,7 @@ export class Veluza extends PokemonCard {
       let energyCount = 0;
       checkProvidedEnergyEffect.energyMap.forEach(em => {
         energyCount += em.provides.filter(cardType =>
-          cardType === CardType.WATER || cardType === CardType.ANY || cardType == CardType.WLFM || cardType == CardType.GRW
+          cardType === CardType.WATER || cardType === CardType.ANY
         ).length;
       });
       effect.damage += energyCount * 20;

--- a/ptcg-server/src/sets/set-scarlet-and-violet/torkoal.ts
+++ b/ptcg-server/src/sets/set-scarlet-and-violet/torkoal.ts
@@ -44,7 +44,7 @@ export class Torkoal extends PokemonCard {
       state = store.reduceEffect(state, checkEnergy);
 
       const totalEnergy = checkEnergy.energyMap.reduce((sum, energy) => {
-        return sum + energy.provides.filter(p => p === CardType.FIRE || p === CardType.ANY || p === CardType.GRW || p === CardType.GRPD).length;
+        return sum + energy.provides.filter(p => p === CardType.FIRE || p === CardType.ANY).length;
       }, 0);
 
       effect.damage = 0;

--- a/ptcg-server/src/sets/set-team-up/articuno.ts
+++ b/ptcg-server/src/sets/set-team-up/articuno.ts
@@ -60,7 +60,7 @@ export class Articuno extends PokemonCard {
         PlayerType.BOTTOM_PLAYER,
         [SlotType.BENCH],
         { superType: SuperType.ENERGY },
-        { allowCancel: false, min: 2, max: 2, validCardTypes: [CardType.WATER, CardType.ANY, CardType.WLFM, CardType.GRW] }
+        { allowCancel: false, min: 2, max: 2, validCardTypes: [CardType.WATER, CardType.ANY] }
       ), transfers => {
         transfers = transfers || [];
         for (const transfer of transfers) {

--- a/ptcg-server/src/sets/set-team-up/mareep.ts
+++ b/ptcg-server/src/sets/set-team-up/mareep.ts
@@ -56,7 +56,7 @@ export class Mareep extends PokemonCard {
 
       const cards: Card[] = [];
       for (const energyMap of checkProvidedEnergy.energyMap) {
-        const energy = energyMap.provides.filter(t => t === CardType.LIGHTNING || t === CardType.ANY || t === CardType.WLFM || t === CardType.LPM);
+        const energy = energyMap.provides.filter(t => t === CardType.LIGHTNING || t === CardType.ANY);
         if (energy.length > 0) {
           cards.push(energyMap.card);
         }

--- a/ptcg-server/src/sets/set-ultra-prism/unit-energy-grw.ts
+++ b/ptcg-server/src/sets/set-ultra-prism/unit-energy-grw.ts
@@ -1,4 +1,5 @@
 import { CardType, EnergyType } from '../../game/store/card/card-types';
+import { CardUtils } from '../../game/store/card/card-utils';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
@@ -30,29 +31,16 @@ export class UnitEnergyGRW extends EnergyCard {
 
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
-      const player = effect.player;
-      const pokemon = effect.source;
-
       try {
-        const energyEffect = new EnergyEffect(player, this);
+        const energyEffect = new EnergyEffect(effect.player, this);
         store.reduceEffect(state, energyEffect);
       } catch {
         return state;
       }
 
-      const pokemonCard = pokemon.getPokemonCard();
-      const attackCosts = pokemonCard?.attacks.map(attack => attack.cost);
-
-      const costs = attackCosts?.flat().filter(t => t !== CardType.COLORLESS) || [];
-      const alreadyProvided = effect.energyMap.flatMap(e => e.provides);
-      const neededType = costs.find(cost =>
-        this.blendedEnergies.includes(cost) &&
-        !alreadyProvided.includes(cost)
-      );
-
       effect.energyMap.push({
         card: this,
-        provides: neededType ? [neededType] : [CardType.COLORLESS]
+        provides: CardUtils.createSpecialEnergyArray(CardType.GRW)
       });
     }
     return state;

--- a/ptcg-server/src/sets/set-ultra-prism/unit-energy-lpm.ts
+++ b/ptcg-server/src/sets/set-ultra-prism/unit-energy-lpm.ts
@@ -1,4 +1,5 @@
 import { CardType, EnergyType } from '../../game/store/card/card-types';
+import { CardUtils } from '../../game/store/card/card-utils';
 import { EnergyCard } from '../../game/store/card/energy-card';
 import { CheckProvidedEnergyEffect } from '../../game/store/effects/check-effects';
 import { Effect } from '../../game/store/effects/effect';
@@ -26,33 +27,18 @@ export class UnitEnergyLPM extends EnergyCard {
     '' +
     'While this card is attached to a Pokémon, it provides [L], [P], and [M] Energy but provides only 1 Energy at a time.';
 
-  blendedEnergies = [CardType.LIGHTNING, CardType.PSYCHIC, CardType.METAL];
-
   public reduceEffect(store: StoreLike, state: State, effect: Effect): State {
     if (effect instanceof CheckProvidedEnergyEffect && effect.source.cards.includes(this)) {
-      const player = effect.player;
-      const pokemon = effect.source;
-
       try {
-        const energyEffect = new EnergyEffect(player, this);
+        const energyEffect = new EnergyEffect(effect.player, this);
         store.reduceEffect(state, energyEffect);
       } catch {
         return state;
       }
 
-      const pokemonCard = pokemon.getPokemonCard();
-      const attackCosts = pokemonCard?.attacks.map(attack => attack.cost);
-
-      const costs = attackCosts?.flat().filter(t => t !== CardType.COLORLESS) || [];
-      const alreadyProvided = effect.energyMap.flatMap(e => e.provides);
-      const neededType = costs.find(cost =>
-        this.blendedEnergies.includes(cost) &&
-        !alreadyProvided.includes(cost)
-      );
-
       effect.energyMap.push({
         card: this,
-        provides: neededType ? [neededType] : [CardType.COLORLESS]
+        provides: CardUtils.createSpecialEnergyArray(CardType.LPM)
       });
     }
     return state;


### PR DESCRIPTION
## Problem
Special Energy cards (Blend Energy, Unit Energy, etc.) weren't being handled consistently across the codebase:

1. The `includes` and `filter` methods of the `EnergyMap.provides` object didn't match the types provided by these Energies
2. The `StateUtils.checkEnoughEnergy` method wasn't correctly expanding these Energies, resulting in order-dependent and inconsistent Energy cost validation
3. Cards were inconsistently using Special Energy type constants (CardType.WLFM, CardType.GRPD, etc.) along with basic Energy types

## Changes
- Added `createSpecialEnergyArray` util method to override both `filter` and `includes` methods in those Energies' `EnergyMap.provides` object:
  - Special Energy cards now properly match their provided basic types for both operations
  - Removed references to Special Energy CardTypes (WLFM, GRPD, etc.) in existing cards
  - Example: Blend Energy WLFM now correctly matches for both `filter(W)` and `includes(W)`

- Improved Energy validation system:
  - Added explicit handling of multi-type energies through `CardUtils.SPECIAL_ENERGY_TYPES`
  - Enhanced backtracking algorithm for Energy cost validation
  - Made Energy cost validation order-independent

## Testing
Added comprehensive test cases covering:
- Basic and Special Energy type matching
- Complex combinations of different special energies
- Order-independent Energy assignment
- Edge cases with multiple special energies
- Consistent behavior between `filter` and `includes` operations
